### PR TITLE
Use DiscoverRunner instead, to add support for Django >= 1.8

### DIFF
--- a/django_test_exclude/runners.py
+++ b/django_test_exclude/runners.py
@@ -1,9 +1,9 @@
-from django.test.simple import DjangoTestSuiteRunner
+from django.test.runner import DiscoverRunner
 from django.conf import settings
 
 EXCLUDED_APPS = getattr(settings, 'TEST_EXCLUDE', [])
 
-class ExcludeTestSuiteRunner(DjangoTestSuiteRunner):
+class ExcludeTestSuiteRunner(DiscoverRunner):
     
     def build_suite(self, *args, **kwargs):
         suite = super(ExcludeTestSuiteRunner, self).build_suite(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author_email='karolmajta@gmail.com',
     description='Easy application excludes for django projects',
     
-    requires=['Django (>=1.8.0)'],
+    requires=['Django (>=1.6.0)'],
 
     packages=['django_test_exclude'],
     package_dir={

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author_email='karolmajta@gmail.com',
     description='Easy application excludes for django projects',
     
-    requires=['Django (>=1.3.0)'],
+    requires=['Django (>=1.8.0)'],
 
     packages=['django_test_exclude'],
     package_dir={


### PR DESCRIPTION
DjangoTestSuiteRunner is deprecated since Django 1.8
https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-1-8

django.test.runner.DiscoverRunner was added in Django 1.6 and works well on Django>=1.6